### PR TITLE
Normalize go file newline to lf

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.go    text eol=lf

--- a/README.md
+++ b/README.md
@@ -13,3 +13,13 @@
 - Test that you can ping the raspberry pi with:
   - ansible -u user all -m ping --ask-pass
 - run `ansible-playbook -i hosts deploy.yml --ask-become-pass`
+
+## Getting Started
+- Clone the repository
+  - `git clone https://github.com/macformula/macfe_ansible.git`
+- Setup Git configurations
+  - In the working directory of the repo, run the below commands
+    
+    `git config core.eol lf`
+    
+    `git config core.autocrlf input`


### PR DESCRIPTION
To avoid line ending bugs with git based on development environments. If we develop cross-platform then these conflicts will occur. And that would likely be the case if someone develops on Windows without an editor capable of LF line ending (and then uses on the Pi or any Unix type system). But we can just normalize to LF always and avoid that